### PR TITLE
Prevent baddies to send IRC commands

### DIFF
--- a/IRC_Bot/Plugins/Linker.pm
+++ b/IRC_Bot/Plugins/Linker.pm
@@ -42,7 +42,9 @@ sub try_get_title { #{{{
 		my $title = $1;
 		$title =~ s/\s+/ /gs;
 		if ($title ne '') {
-			return decode_entities($title);
+			$title = decode_entities($title);
+			$title =~ s/\r\n//gs
+			return $title;
 		}
 	}
 	else {

--- a/IRC_Bot/Plugins/Linker.pm
+++ b/IRC_Bot/Plugins/Linker.pm
@@ -43,7 +43,7 @@ sub try_get_title { #{{{
 		$title =~ s/\s+/ /gs;
 		if ($title ne '') {
 			$title = decode_entities($title);
-			$title =~ s/\r\n//gs
+			$title =~ s/[\r\n]//gs
 			return $title;
 		}
 	}


### PR DESCRIPTION
If the title controls the html chars for a newline, irc_bot interprets it and sends the newline back to the IRC server. It is thus possible to make him send messages, change his nick, etc…

Credit for finding the vuln go to countzero
